### PR TITLE
Allow token in environment variable

### DIFF
--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -15,7 +15,7 @@ class Bot extends Client {
    * @returns The token used.
    */
   async login(token?: string): Promise<string> {
-    return super.login(token || this.config.token);
+    return super.login(token || this.config.token || process.env['MU_TOKEN']);
   }
 }
 


### PR DESCRIPTION
Falls back to token from environment variable if not provided or in config. This may be useful in deployment environments like heroku where they recommend using env vars for this kind of thing

I haven't tested this. Is a triple `||` chain like here allowed?